### PR TITLE
Add Slack Attachments message support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,43 @@
-Build Slackbots in Go
--------------------------------
+## go-slackbot - Build Slackbots in Go
 
-Sometime in the near future... at the present this is an extreme work in progress
+The go-slackbot project hopes to ease development of Slack bots by adding helpful
+methods and a mux-router style interface to the github.com/nlopes/slack package.
 
-For now, if you want to kick the tires, we would love feedback. Check out these two examples:
+Incoming Slack RTM events are mapped to a handler in the following form:
+
+	bot.Hear("(?i)how are you(.*)").MessageHandler(HowAreYouHandler)
+
+In addition to several useful functions in the utils.go file, the slackbot.Bot struct provides handy Reply and ReplyWithAttachments methods:
+
+	func HowAreYouHandler(ctx context.Context, bot *slackbot.Bot, evt *slack.MessageEvent) {
+		bot.Reply(evt, "A bit tired. You get it? A bit?", slackbot.WithTyping)
+	}
+&nbsp;
+
+	func HowAreYouAttachmentsHandler(ctx context.Context, bot *slackbot.Bot, evt *slack.MessageEvent) {
+		txt := "Beep Beep Boop is a ridiculously simple hosting platform for your Slackbots."
+		attachment := slack.Attachment{
+			Pretext:   "We bring bots to life. :sunglasses: :thumbsup:",
+			Title:     "Host, deploy and share your bot in seconds.",
+			TitleLink: "https:beepboophq.com/",
+			Text:      txt,
+			Fallback:  txt,
+			ImageURL:  "https:storage.googleapis.com/beepboophq/_assets/bot-1.22f6fb.png",
+			Color:     "#7CD197",
+		}
+
+		attachments := []slack.Attachment{attachment}
+		bot.ReplyWithAttachments(evt, attachments, slackbot.WithTyping)
+	}
+  
+But wait, there's more! Well, until there's more, the slackbot package exposes github.com/nlopes/slack RTM and Client objects enabling a consumer to interact with the lower level package directly:
+
+    func HowAreYouHandler(ctx context.Context, bot *slackbot.Bot, evt *slack.MessageEvent) {
+      bot.RTM.NewOutgoingMessage("Hello", "#random")
+    }
+
+
+If you want to kick the tires, we would love feedback. Check out these two examples:
 
 - [simple.go](https://github.com/BeepBoopHQ/go-slackbot/blob/master/examples/simple/simple.go)
 - [wit.go](https://github.com/BeepBoopHQ/go-slackbot/blob/master/examples/wit/wit.go).

--- a/bot.go
+++ b/bot.go
@@ -85,3 +85,11 @@ func (b *Bot) Type(channel, text string) {
 	b.RTM.SendMessage(b.RTM.NewTypingMessage(channel))
 	time.Sleep(sleepDuration)
 }
+
+func (b *Bot) BotUserID() string {
+	return b.botUserID
+}
+
+func (b *Bot) SetBotID(ID string) {
+	b.botUserID = ID
+}

--- a/bot.go
+++ b/bot.go
@@ -1,3 +1,38 @@
+// Package slackbot hopes to ease development of Slack bots by adding helpful
+// methods and a mux-router style interface to the github.com/nlopes/slack package.
+//
+// Incoming Slack RTM events are mapped to a handler in the following form:
+// 	bot.Hear("(?i)how are you(.*)").MessageHandler(HowAreYouHandler)
+//
+// The package adds Reply and ReplyWithAttachments methods:
+//	func HowAreYouHandler(ctx context.Context, bot *slackbot.Bot, evt *slack.MessageEvent) {
+// 		bot.Reply(evt, "A bit tired. You get it? A bit?", slackbot.WithTyping)
+//	}
+//
+//	func HowAreYouAttachmentsHandler(ctx context.Context, bot *slackbot.Bot, evt *slack.MessageEvent) {
+// 		txt := "Beep Beep Boop is a ridiculously simple hosting platform for your Slackbots."
+// 		attachment := slack.Attachment{
+// 			Pretext:   "We bring bots to life. :sunglasses: :thumbsup:",
+// 			Title:     "Host, deploy and share your bot in seconds.",
+// 			TitleLink: "https://beepboophq.com/",
+// 			Text:      txt,
+// 			Fallback:  txt,
+// 			ImageURL:  "https://storage.googleapis.com/beepboophq/_assets/bot-1.22f6fb.png",
+// 			Color:     "#7CD197",
+// 		}
+//
+//		attachments := []slack.Attachment{attachment}
+//		bot.ReplyWithAttachments(evt, attachments, slackbot.WithTyping)
+//	}
+//
+// The slackbot package exposes  github.com/nlopes/slack RTM and Client objects
+// enabling a consumer to interact with the lower level package directly:
+// 	func HowAreYouHandler(ctx context.Context, bot *slackbot.Bot, evt *slack.MessageEvent) {
+// 		bot.RTM.NewOutgoingMessage("Hello", "#random")
+// 	}
+//
+//
+// Project home and samples: https://github.com/BeepBoopHQ/go-slackbot
 package slackbot
 
 import (

--- a/examples/simple/simple.go
+++ b/examples/simple/simple.go
@@ -5,7 +5,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/BeepBoopHQ/go-slackbot"
+	slackbot "github.com/BeepBoopHQ/go-slackbot"
 	"github.com/nlopes/slack"
 )
 
@@ -19,15 +19,15 @@ func main() {
 	bot.Run()
 }
 
-func HelloHandler(ctx context.Context, bot *slackbot.Bot, msg *slack.MessageEvent) {
-	bot.ReplyAndType(msg, "Oh hello!")
+func HelloHandler(ctx context.Context, bot *slackbot.Bot, evt *slack.MessageEvent) {
+	bot.Reply(evt, "Oh hello!", slackbot.WithTyping)
 }
 
-func HowAreYouHandler(ctx context.Context, bot *slackbot.Bot, msg *slack.MessageEvent) {
-	bot.ReplyAndType(msg, "A bit tired. You get it? A bit?")
+func HowAreYouHandler(ctx context.Context, bot *slackbot.Bot, evt *slack.MessageEvent) {
+	bot.Reply(evt, "A bit tired. You get it? A bit?", slackbot.WithTyping)
 }
 
-func AttachmentsHandler(ctx context.Context, bot *slackbot.Bot, msg *slack.MessageEvent) {
+func AttachmentsHandler(ctx context.Context, bot *slackbot.Bot, evt *slack.MessageEvent) {
 	txt := "Beep Beep Boop is a ridiculously simple hosting platform for your Slackbots."
 	attachment := slack.Attachment{
 		Pretext:   "We bring bots to life. :sunglasses: :thumbsup:",
@@ -42,6 +42,5 @@ func AttachmentsHandler(ctx context.Context, bot *slackbot.Bot, msg *slack.Messa
 	// supports multiple attachments
 	attachments := []slack.Attachment{attachment}
 
-	typingDelay := 4
-	bot.ReplyAttachmentsAndType(msg, typingDelay, attachments)
+	bot.ReplyWithAttachments(evt, attachments, slackbot.WithTyping)
 }

--- a/examples/simple/simple.go
+++ b/examples/simple/simple.go
@@ -15,6 +15,7 @@ func main() {
 	toMe := bot.Messages(slackbot.DirectMessage, slackbot.DirectMention).Subrouter()
 	toMe.Hear("(?i)(hi|hello).*").MessageHandler(HelloHandler)
 	bot.Hear("(?i)how are you(.*)").MessageHandler(HowAreYouHandler)
+	bot.Hear("(?)attachment").MessageHandler(AttachmentsHandler)
 	bot.Run()
 }
 
@@ -24,4 +25,23 @@ func HelloHandler(ctx context.Context, bot *slackbot.Bot, msg *slack.MessageEven
 
 func HowAreYouHandler(ctx context.Context, bot *slackbot.Bot, msg *slack.MessageEvent) {
 	bot.ReplyAndType(msg, "A bit tired. You get it? A bit?")
+}
+
+func AttachmentsHandler(ctx context.Context, bot *slackbot.Bot, msg *slack.MessageEvent) {
+	txt := "Beep Beep Boop is a ridiculously simple hosting platform for your Slackbots."
+	attachment := slack.Attachment{
+		Pretext:   "We bring bots to life. :sunglasses: :thumbsup:",
+		Title:     "Host, deploy and share your bot in seconds.",
+		TitleLink: "https://beepboophq.com/",
+		Text:      txt,
+		Fallback:  txt,
+		ImageURL:  "https://storage.googleapis.com/beepboophq/_assets/bot-1.22f6fb.png",
+		Color:     "#7CD197",
+	}
+
+	// supports multiple attachments
+	attachments := []slack.Attachment{attachment}
+
+	typingDelay := 4
+	bot.ReplyAttachmentsAndType(msg, typingDelay, attachments)
 }

--- a/examples/wit/wit.go
+++ b/examples/wit/wit.go
@@ -7,7 +7,7 @@ import (
 	"golang.org/x/net/context"
 
 	slackbot "github.com/BeepBoopHQ/go-slackbot"
-	"github.com/jsgoecke/go-wit"
+	"github.com/chris-skud/go-wit"
 	"github.com/nlopes/slack"
 )
 

--- a/examples/wit/wit.go
+++ b/examples/wit/wit.go
@@ -6,7 +6,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/BeepBoopHQ/go-slackbot"
+	slackbot "github.com/BeepBoopHQ/go-slackbot"
 	"github.com/jsgoecke/go-wit"
 	"github.com/nlopes/slack"
 )
@@ -21,15 +21,15 @@ func main() {
 }
 
 func HelloHandler(ctx context.Context, bot *slackbot.Bot, msg *slack.MessageEvent) {
-	bot.ReplyAndType(msg, "Oh hello!")
+	bot.Reply(msg, "Oh hello!", slackbot.WithTyping)
 }
 
 func HowAreYouHandler(ctx context.Context, bot *slackbot.Bot, msg *slack.MessageEvent) {
-	bot.ReplyAndType(msg, "A bit tired. You get it? A bit?")
+	bot.Reply(msg, "A bit tired. You get it? A bit?", slackbot.WithTyping)
 }
 
 func ConfusedHandler(ctx context.Context, bot *slackbot.Bot, msg *slack.MessageEvent) {
-	bot.ReplyAndType(msg, "I don't understand 😰")
+	bot.Reply(msg, "I don't understand 😰", slackbot.WithTyping)
 }
 
 func WitPreprocess(ctx context.Context) context.Context {
@@ -39,7 +39,7 @@ func WitPreprocess(ctx context.Context) context.Context {
 	witMessage, err := wit.NewClient(os.Getenv("WIT_TOKEN")).Message(req)
 	if err != nil {
 		bot := slackbot.BotFromContext(ctx)
-		bot.Reply(msg, "Uh oh, I seem to be out of sorts :dizzy_face")
+		bot.Reply(msg, "Uh oh, I seem to be out of sorts :dizzy_face", slackbot.WithTyping)
 		return ctx
 	}
 	fmt.Printf("WIT: %#v\n", witMessage)


### PR DESCRIPTION
#### What's this PR do?
- Added support for Slack attachment messages. Includes modification to the "Type" (aka "typing") method to take a typingDelaySecs as the msg length calculation isn't useful when the message is a json object. 
- Add exported BotUserID methods to enable consumers to get the bot user id.
#### How should this be manually tested?

Run simple.go in the examples folder:
`SLACK_TOKEN=<YOUR TOKEN> go run simple.go`

DM the bot `attachment`
