### PR TITLE
Fix direct mentions

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -144,6 +144,7 @@ func (b *Bot) BotUserID() string {
 
 func (b *Bot) setBotID(ID string) {
 	b.botUserID = ID
+	b.SimpleRouter.SetBotID(ID)
 }
 
 // msgLen gets lenght of message and attachment messages. Unsupported types return 0.


### PR DESCRIPTION
Mentions were ignored previously, because the bot ID was never set on
any of the routes. This sets the ID when the bot is run.
